### PR TITLE
Refactor eviction system

### DIFF
--- a/2q.go
+++ b/2q.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/hashicorp/golang-lru/simplelru"
+	"github.com/optakt/golang-lru/simplelru"
 )
 
 const (

--- a/README.md
+++ b/README.md
@@ -1,16 +1,11 @@
-golang-lru
-==========
+# golang-lru
 
 This provides the `lru` package which implements a fixed-size
-thread safe LRU cache. It is based on the cache in Groupcache.
+thread safe LRU cache. It is based on the Hashicorp LRU cache, which itself is based on Groupcache.
 
-Documentation
-=============
+Full docs are available on [Godoc](http://godoc.org/github.com/optakt/golang-lru)
 
-Full docs are available on [Godoc](http://godoc.org/github.com/hashicorp/golang-lru)
-
-Example
-=======
+## Example
 
 Using the LRU is very simple:
 

--- a/arc.go
+++ b/arc.go
@@ -3,7 +3,7 @@ package lru
 import (
 	"sync"
 
-	"github.com/hashicorp/golang-lru/simplelru"
+	"github.com/optakt/golang-lru/simplelru"
 )
 
 // ARCCache is a thread-safe fixed size Adaptive Replacement Cache (ARC).

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/hashicorp/golang-lru
+module github.com/optakt/golang-lru
 
 go 1.12

--- a/lru_test.go
+++ b/lru_test.go
@@ -67,89 +67,223 @@ func BenchmarkLRU_Freq(b *testing.B) {
 }
 
 func TestLRU(t *testing.T) {
-	evictCounter := 0
-	onEvicted := func(k interface{}, v interface{}) {
-		if k != v {
-			t.Fatalf("Evict values not equal (%v!=%v)", k, v)
-		}
-		evictCounter++
-	}
-	l, err := NewWithEvict(128, onEvicted)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	t.Run("without aborted eviction", func(t *testing.T) {
+		t.Parallel()
 
-	for i := 0; i < 256; i++ {
-		l.Add(i, i)
-	}
-	if l.Len() != 128 {
-		t.Fatalf("bad len: %v", l.Len())
-	}
-
-	if evictCounter != 128 {
-		t.Fatalf("bad evict count: %v", evictCounter)
-	}
-
-	for i, k := range l.Keys() {
-		if v, ok := l.Get(k); !ok || v != k || v != i+128 {
-			t.Fatalf("bad key: %v", k)
+		evictCounter := 0
+		onEvicted := func(k interface{}, v interface{}) bool {
+			if k != v {
+				t.Fatalf("Evict values not equal (%v!=%v)", k, v)
+			}
+			evictCounter++
+			return true
 		}
-	}
-	for i := 0; i < 128; i++ {
-		_, ok := l.Get(i)
-		if ok {
-			t.Fatalf("should be evicted")
+		l, err := NewWithEvict(128, onEvicted)
+		if err != nil {
+			t.Fatalf("err: %v", err)
 		}
-	}
-	for i := 128; i < 256; i++ {
-		_, ok := l.Get(i)
+
+		for i := 0; i < 256; i++ {
+			l.Add(i, i)
+		}
+		if l.Len() != 128 {
+			t.Fatalf("bad len: %v", l.Len())
+		}
+
+		if evictCounter != 128 {
+			t.Fatalf("bad evict count: %v", evictCounter)
+		}
+
+		for i, k := range l.Keys() {
+			if v, ok := l.Get(k); !ok || v != k || v != i+128 {
+				t.Fatalf("bad key: %v", k)
+			}
+		}
+		for i := 0; i < 128; i++ {
+			_, ok := l.Get(i)
+			if ok {
+				t.Fatalf("should be evicted")
+			}
+		}
+		for i := 128; i < 256; i++ {
+			_, ok := l.Get(i)
+			if !ok {
+				t.Fatalf("should not be evicted")
+			}
+		}
+		for i := 128; i < 192; i++ {
+			l.Remove(i)
+			_, ok := l.Get(i)
+			if ok {
+				t.Fatalf("should be deleted")
+			}
+		}
+
+		l.Get(192) // expect 192 to be last key in l.Keys()
+
+		for i, k := range l.Keys() {
+			if (i < 63 && k != i+193) || (i == 63 && k != 192) {
+				t.Fatalf("out of order key: %v", k)
+			}
+		}
+
+		l.Purge()
+		if l.Len() != 0 {
+			t.Fatalf("bad len: %v", l.Len())
+		}
+		if _, ok := l.Get(200); ok {
+			t.Fatalf("should contain nothing")
+		}
+	})
+
+	t.Run("with aborted eviction", func(t *testing.T) {
+		t.Parallel()
+
+		abortEviction := true
+		evictCounter := 0
+		onEvicted := func(k interface{}, v interface{}) bool {
+			if k != v {
+				t.Fatalf("Evict values not equal (%v!=%v)", k, v)
+			}
+			evictCounter++
+
+			// Abort the first eviction.
+			// The next entry should be evicted instead, then.
+			if abortEviction {
+				abortEviction = false
+				return false
+			}
+			return true
+		}
+		l, err := NewWithEvict(128, onEvicted)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		for i := 0; i < 256; i++ {
+			l.Add(i, i)
+		}
+		if l.Len() != 128 {
+			t.Fatalf("bad len: %v", l.Len())
+		}
+
+		if evictCounter != 129 {
+			t.Fatalf("bad evict count: %v", evictCounter)
+		}
+
+		for i, k := range l.Keys() {
+			v, ok := l.Get(k)
+			if !ok {
+				t.Fatalf("should contain key: %v", k)
+			}
+
+			// Oldest value's eviction should have been aborted.
+			if i == 0 && v != k {
+				t.Fatalf("bad key: got %v want 0", k)
+			}
+
+			// From then on, we expect normal key values.
+			if i != 0 && (v != k || v != i+128) {
+				t.Fatalf("bad key: got %v want %d", k, i+128)
+			}
+		}
+		for i := 1; i < 129; i++ {
+			_, ok := l.Get(i)
+			if ok {
+				t.Fatalf("should be evicted")
+			}
+		}
+
+		_, ok := l.Get(0)
 		if !ok {
 			t.Fatalf("should not be evicted")
 		}
-	}
-	for i := 128; i < 192; i++ {
-		l.Remove(i)
-		_, ok := l.Get(i)
-		if ok {
-			t.Fatalf("should be deleted")
+		for i := 129; i < 256; i++ {
+			_, ok := l.Get(i)
+			if !ok {
+				t.Fatalf("should not be evicted")
+			}
 		}
-	}
-
-	l.Get(192) // expect 192 to be last key in l.Keys()
-
-	for i, k := range l.Keys() {
-		if (i < 63 && k != i+193) || (i == 63 && k != 192) {
-			t.Fatalf("out of order key: %v", k)
+		for i := 129; i < 193; i++ {
+			l.Remove(i)
+			_, ok := l.Get(i)
+			if ok {
+				t.Fatalf("should be deleted")
+			}
 		}
-	}
 
-	l.Purge()
-	if l.Len() != 0 {
-		t.Fatalf("bad len: %v", l.Len())
-	}
-	if _, ok := l.Get(200); ok {
-		t.Fatalf("should contain nothing")
-	}
+		l.Get(193) // expect 192 to be last key in l.Keys()
+
+		for i, k := range l.Keys() {
+			if i == 0 && k == 0 {
+				continue
+			}
+			if (i < 63 && k != i+193) || (i == 63 && k != 193) {
+				t.Fatalf("out of order key: %v", k)
+			}
+		}
+
+		l.Purge()
+		if l.Len() != 0 {
+			t.Fatalf("bad len: %v", l.Len())
+		}
+		if _, ok := l.Get(200); ok {
+			t.Fatalf("should contain nothing")
+		}
+	})
 }
 
 // test that Add returns true/false if an eviction occurred
 func TestLRUAdd(t *testing.T) {
-	evictCounter := 0
-	onEvicted := func(k interface{}, v interface{}) {
-		evictCounter++
-	}
+	t.Run("without aborted eviction", func(t *testing.T) {
+		t.Parallel()
 
-	l, err := NewWithEvict(1, onEvicted)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+		evictCounter := 0
+		onEvicted := func(k interface{}, v interface{}) bool {
+			evictCounter++
+			return true
+		}
 
-	if l.Add(1, 1) == true || evictCounter != 0 {
-		t.Errorf("should not have an eviction")
-	}
-	if l.Add(2, 2) == false || evictCounter != 1 {
-		t.Errorf("should have an eviction")
-	}
+		l, err := NewWithEvict(1, onEvicted)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		if l.Add(1, 1) == true || evictCounter != 0 {
+			t.Errorf("should not have an eviction")
+		}
+		if l.Add(2, 2) == false || evictCounter != 1 {
+			t.Errorf("should have an eviction")
+		}
+	})
+
+	t.Run("with aborted eviction", func(t *testing.T) {
+		t.Parallel()
+
+		abortEviction := true
+		evictCounter := 0
+		onEvicted := func(k interface{}, v interface{}) bool {
+			evictCounter++
+
+			if abortEviction {
+				abortEviction = false
+				return false
+			}
+			return true
+		}
+
+		l, err := NewWithEvict(1, onEvicted)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		if l.Add(1, 1) == true || evictCounter != 0 {
+			t.Errorf("should not have an eviction")
+		}
+		if l.Add(2, 2) == false || evictCounter != 2 {
+			t.Errorf("should have one aborted eviction and a successful one")
+		}
+	})
 }
 
 // test that Contains doesn't update recent-ness
@@ -255,39 +389,98 @@ func TestLRUPeek(t *testing.T) {
 
 // test that Resize can upsize and downsize
 func TestLRUResize(t *testing.T) {
-	onEvictCounter := 0
-	onEvicted := func(k interface{}, v interface{}) {
-		onEvictCounter++
-	}
-	l, err := NewWithEvict(2, onEvicted)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	t.Run("without aborted eviction", func(t *testing.T) {
+		t.Parallel()
 
-	// Downsize
-	l.Add(1, 1)
-	l.Add(2, 2)
-	evicted := l.Resize(1)
-	if evicted != 1 {
-		t.Errorf("1 element should have been evicted: %v", evicted)
-	}
-	if onEvictCounter != 1 {
-		t.Errorf("onEvicted should have been called 1 time: %v", onEvictCounter)
-	}
+		onEvictCounter := 0
+		onEvicted := func(k interface{}, v interface{}) bool {
+			onEvictCounter++
+			return true
+		}
+		l, err := NewWithEvict(2, onEvicted)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
 
-	l.Add(3, 3)
-	if l.Contains(1) {
-		t.Errorf("Element 1 should have been evicted")
-	}
+		// Downsize
+		l.Add(1, 1)
+		l.Add(2, 2)
+		evicted := l.Resize(1)
+		if evicted != 1 {
+			t.Errorf("1 element should have been evicted: %v", evicted)
+		}
+		if onEvictCounter != 1 {
+			t.Errorf("onEvicted should have been called once: %v", onEvictCounter)
+		}
 
-	// Upsize
-	evicted = l.Resize(2)
-	if evicted != 0 {
-		t.Errorf("0 elements should have been evicted: %v", evicted)
-	}
+		l.Add(3, 3)
+		if l.Contains(1) {
+			t.Errorf("Element 1 should have been evicted")
+		}
 
-	l.Add(4, 4)
-	if !l.Contains(3) || !l.Contains(4) {
-		t.Errorf("Cache should have contained 2 elements")
-	}
+		// Upsize
+		evicted = l.Resize(2)
+		if evicted != 0 {
+			t.Errorf("0 elements should have been evicted: %v", evicted)
+		}
+
+		l.Add(4, 4)
+		if !l.Contains(3) || !l.Contains(4) {
+			t.Errorf("Cache should have contained 2 elements")
+		}
+	})
+
+	t.Run("with aborted eviction", func(t *testing.T) {
+		t.Parallel()
+
+		abortEviction := true
+		onEvictCounter := 0
+		onEvicted := func(k interface{}, v interface{}) bool {
+			onEvictCounter++
+
+			if abortEviction {
+				abortEviction = false
+				return false
+			}
+			return true
+		}
+
+		l, err := NewWithEvict(2, onEvicted)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		// Downsize
+		l.Add(1, 1)
+		l.Add(2, 2)
+		evicted := l.Resize(1)
+		if evicted != 1 {
+			t.Errorf("1 element should have been evicted: %v", evicted)
+		}
+		if onEvictCounter != 2 {
+			t.Errorf("onEvicted should have been called twice: %v", onEvictCounter)
+		}
+		if !l.Contains(1) {
+			t.Errorf("Element 1 should not have been evicted")
+		}
+		if l.Contains(2) {
+			t.Errorf("Element 2 should have been evicted")
+		}
+
+		l.Add(3, 3)
+		if l.Contains(1) {
+			t.Errorf("Element 1 should have been evicted")
+		}
+
+		// Upsize
+		evicted = l.Resize(2)
+		if evicted != 0 {
+			t.Errorf("0 elements should have been evicted: %v", evicted)
+		}
+
+		l.Add(4, 4)
+		if !l.Contains(3) || !l.Contains(4) {
+			t.Errorf("Cache should have contained 2 elements")
+		}
+	})
 }

--- a/simplelru/lru_interface.go
+++ b/simplelru/lru_interface.go
@@ -8,7 +8,7 @@ type LRUCache interface {
 	Add(key, value interface{}) bool
 
 	// Returns key's value from the cache and
-	// updates the "recently used"-ness of the key. #value, isFound
+	// updates the "recently used"-ness of the key.
 	Get(key interface{}) (value interface{}, ok bool)
 
 	// Checks if a key exists in cache without updating the recent-ness.
@@ -21,10 +21,10 @@ type LRUCache interface {
 	Remove(key interface{}) bool
 
 	// Removes the oldest entry from cache.
-	RemoveOldest() (interface{}, interface{}, bool)
+	RemoveOldest() (key interface{}, value interface{}, ok bool)
 
-	// Returns the oldest entry from the cache. #key, value, isFound
-	GetOldest() (interface{}, interface{}, bool)
+	// Returns the oldest entry from the cache.
+	GetOldest() (key interface{}, value interface{}, ok bool)
 
 	// Returns a slice of the keys in the cache, from oldest to newest.
 	Keys() []interface{}

--- a/simplelru/lru_test.go
+++ b/simplelru/lru_test.go
@@ -1,78 +1,184 @@
 package simplelru
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestLRU(t *testing.T) {
-	evictCounter := 0
-	onEvicted := func(k interface{}, v interface{}) {
-		if k != v {
-			t.Fatalf("Evict values not equal (%v!=%v)", k, v)
+	t.Run("without aborted eviction", func(t *testing.T) {
+		evictCounter := 0
+		onEvicted := func(k interface{}, v interface{}) bool {
+			if k != v {
+				t.Fatalf("Evict values not equal (%v!=%v)", k, v)
+			}
+			evictCounter++
+			return true
 		}
-		evictCounter++
-	}
-	l, err := NewLRU(128, onEvicted)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
-	for i := 0; i < 256; i++ {
-		l.Add(i, i)
-	}
-	if l.Len() != 128 {
-		t.Fatalf("bad len: %v", l.Len())
-	}
-
-	if evictCounter != 128 {
-		t.Fatalf("bad evict count: %v", evictCounter)
-	}
-
-	for i, k := range l.Keys() {
-		if v, ok := l.Get(k); !ok || v != k || v != i+128 {
-			t.Fatalf("bad key: %v", k)
+		l, err := NewLRU(128, onEvicted)
+		if err != nil {
+			t.Fatalf("err: %v", err)
 		}
-	}
-	for i := 0; i < 128; i++ {
-		_, ok := l.Get(i)
-		if ok {
-			t.Fatalf("should be evicted")
+
+		for i := 0; i < 256; i++ {
+			l.Add(i, i)
 		}
-	}
-	for i := 128; i < 256; i++ {
-		_, ok := l.Get(i)
+		if l.Len() != 128 {
+			t.Fatalf("bad len: %v", l.Len())
+		}
+
+		if evictCounter != 128 {
+			t.Fatalf("bad evict count: %v", evictCounter)
+		}
+
+		for i, k := range l.Keys() {
+			if v, ok := l.Get(k); !ok || v != k || v != i+128 {
+				t.Fatalf("bad key: %v", k)
+			}
+		}
+		for i := 0; i < 128; i++ {
+			_, ok := l.Get(i)
+			if ok {
+				t.Fatalf("should be evicted")
+			}
+		}
+		for i := 128; i < 256; i++ {
+			_, ok := l.Get(i)
+			if !ok {
+				t.Fatalf("should not be evicted")
+			}
+		}
+		for i := 128; i < 192; i++ {
+			ok := l.Remove(i)
+			if !ok {
+				t.Fatalf("should be contained")
+			}
+			ok = l.Remove(i)
+			if ok {
+				t.Fatalf("should not be contained")
+			}
+			_, ok = l.Get(i)
+			if ok {
+				t.Fatalf("should be deleted")
+			}
+		}
+
+		l.Get(192) // expect 192 to be last key in l.Keys()
+
+		for i, k := range l.Keys() {
+			if (i < 63 && k != i+193) || (i == 63 && k != 192) {
+				t.Fatalf("out of order key: %v", k)
+			}
+		}
+
+		l.Purge()
+		if l.Len() != 0 {
+			t.Fatalf("bad len: %v", l.Len())
+		}
+		if _, ok := l.Get(200); ok {
+			t.Fatalf("should contain nothing")
+		}
+	})
+
+	t.Run("with aborted eviction", func(t *testing.T) {
+		abortEviction := true
+		evictCounter := 0
+		onEvicted := func(k interface{}, v interface{}) bool {
+			if k != v {
+				t.Fatalf("Evict values not equal (%v!=%v)", k, v)
+			}
+			evictCounter++
+
+			// Abort the first eviction.
+			// The next entry should be evicted instead, then.
+			if abortEviction {
+				abortEviction = false
+				return false
+			}
+			return true
+		}
+		l, err := NewLRU(128, onEvicted)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		for i := 0; i < 256; i++ {
+			l.Add(i, i)
+		}
+		if l.Len() != 128 {
+			t.Fatalf("bad len: %v", l.Len())
+		}
+
+		if evictCounter != 129 {
+			t.Fatalf("bad evict count: %v", evictCounter)
+		}
+
+		for i, k := range l.Keys() {
+			v, ok := l.Get(k)
+			if !ok {
+				t.Fatalf("should contain key: %v", k)
+			}
+
+			// Oldest value's eviction should have been aborted.
+			if i == 0 && v != k {
+				t.Fatalf("bad key: got %v want 0", k)
+			}
+
+			// From then on, we expect normal key values.
+			if i != 0 && (v != k || v != i+128) {
+				t.Fatalf("bad key: got %v want %d", k, i+128)
+			}
+		}
+		for i := 1; i < 129; i++ {
+			_, ok := l.Get(i)
+			if ok {
+				t.Fatalf("should be evicted")
+			}
+		}
+
+		_, ok := l.Get(0)
 		if !ok {
 			t.Fatalf("should not be evicted")
 		}
-	}
-	for i := 128; i < 192; i++ {
-		ok := l.Remove(i)
-		if !ok {
-			t.Fatalf("should be contained")
+		for i := 129; i < 256; i++ {
+			_, ok := l.Get(i)
+			if !ok {
+				t.Fatalf("should not be evicted")
+			}
 		}
-		ok = l.Remove(i)
-		if ok {
-			t.Fatalf("should not be contained")
+		for i := 129; i < 193; i++ {
+			ok := l.Remove(i)
+			if !ok {
+				t.Fatalf("should be contained")
+			}
+			ok = l.Remove(i)
+			if ok {
+				t.Fatalf("should not be contained")
+			}
+			_, ok = l.Get(i)
+			if ok {
+				t.Fatalf("should be deleted")
+			}
 		}
-		_, ok = l.Get(i)
-		if ok {
-			t.Fatalf("should be deleted")
-		}
-	}
 
-	l.Get(192) // expect 192 to be last key in l.Keys()
+		l.Get(193) // expect 192 to be last key in l.Keys()
 
-	for i, k := range l.Keys() {
-		if (i < 63 && k != i+193) || (i == 63 && k != 192) {
-			t.Fatalf("out of order key: %v", k)
+		for i, k := range l.Keys() {
+			if i == 0 && k == 0 {
+				continue
+			}
+			if (i < 63 && k != i+193) || (i == 63 && k != 193) {
+				t.Fatalf("out of order key: %v", k)
+			}
 		}
-	}
 
-	l.Purge()
-	if l.Len() != 0 {
-		t.Fatalf("bad len: %v", l.Len())
-	}
-	if _, ok := l.Get(200); ok {
-		t.Fatalf("should contain nothing")
-	}
+		l.Purge()
+		if l.Len() != 0 {
+			t.Fatalf("bad len: %v", l.Len())
+		}
+		if _, ok := l.Get(200); ok {
+			t.Fatalf("should contain nothing")
+		}
+	})
 }
 
 func TestLRU_GetOldest_RemoveOldest(t *testing.T) {
@@ -110,22 +216,57 @@ func TestLRU_GetOldest_RemoveOldest(t *testing.T) {
 
 // Test that Add returns true/false if an eviction occurred
 func TestLRU_Add(t *testing.T) {
-	evictCounter := 0
-	onEvicted := func(k interface{}, v interface{}) {
-		evictCounter++
-	}
+	t.Run("without aborted eviction", func(t *testing.T) {
+		t.Parallel()
 
-	l, err := NewLRU(1, onEvicted)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+		evictCounter := 0
+		onEvicted := func(k interface{}, v interface{}) bool {
+			evictCounter++
+			return true
+		}
 
-	if l.Add(1, 1) == true || evictCounter != 0 {
-		t.Errorf("should not have an eviction")
-	}
-	if l.Add(2, 2) == false || evictCounter != 1 {
-		t.Errorf("should have an eviction")
-	}
+		l, err := NewLRU(1, onEvicted)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		if l.Add(1, 1) == true || evictCounter != 0 {
+			t.Errorf("should not have an eviction")
+		}
+		if l.Add(2, 2) == false || evictCounter != 1 {
+			t.Errorf("should have an eviction")
+		}
+	})
+
+	t.Run("with aborted eviction", func(t *testing.T) {
+		t.Parallel()
+
+		abortEviction := true
+		evictCounter := 0
+		onEvicted := func(k interface{}, v interface{}) bool {
+			evictCounter++
+
+			// Abort the first eviction.
+			// The next entry should be evicted instead, then.
+			if abortEviction {
+				abortEviction = false
+				return false
+			}
+			return true
+		}
+
+		l, err := NewLRU(1, onEvicted)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		if l.Add(1, 1) == true || evictCounter != 0 {
+			t.Errorf("should not have an eviction")
+		}
+		if l.Add(2, 2) == false || evictCounter != 2 {
+			t.Errorf("should have an eviction")
+		}
+	})
 }
 
 // Test that Contains doesn't update recent-ness
@@ -168,39 +309,105 @@ func TestLRU_Peek(t *testing.T) {
 
 // Test that Resize can upsize and downsize
 func TestLRU_Resize(t *testing.T) {
-	onEvictCounter := 0
-	onEvicted := func(k interface{}, v interface{}) {
-		onEvictCounter++
-	}
-	l, err := NewLRU(2, onEvicted)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	t.Run("without aborted evictions", func(t *testing.T) {
+		t.Parallel()
 
-	// Downsize
-	l.Add(1, 1)
-	l.Add(2, 2)
-	evicted := l.Resize(1)
-	if evicted != 1 {
-		t.Errorf("1 element should have been evicted: %v", evicted)
-	}
-	if onEvictCounter != 1 {
-		t.Errorf("onEvicted should have been called 1 time: %v", onEvictCounter)
-	}
+		onEvictCounter := 0
+		onEvicted := func(k interface{}, v interface{}) bool {
+			onEvictCounter++
+			return true
+		}
+		l, err := NewLRU(2, onEvicted)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
 
-	l.Add(3, 3)
-	if l.Contains(1) {
-		t.Errorf("Element 1 should have been evicted")
-	}
+		// Downsize
+		l.Add(1, 1)
+		l.Add(2, 2)
+		evicted := l.Resize(1)
+		if evicted != 1 {
+			t.Errorf("1 element should have been evicted: %v", evicted)
+		}
+		if onEvictCounter != 1 {
+			t.Errorf("onEvicted should have been called once: %v", onEvictCounter)
+		}
 
-	// Upsize
-	evicted = l.Resize(2)
-	if evicted != 0 {
-		t.Errorf("0 elements should have been evicted: %v", evicted)
-	}
+		l.Add(3, 3)
+		if l.Contains(1) {
+			t.Errorf("Element 1 should have been evicted")
+		}
 
-	l.Add(4, 4)
-	if !l.Contains(3) || !l.Contains(4) {
-		t.Errorf("Cache should have contained 2 elements")
-	}
+		// Upsize
+		evicted = l.Resize(2)
+		if evicted != 0 {
+			t.Errorf("0 elements should have been evicted: %v", evicted)
+		}
+
+		l.Add(4, 4)
+		if !l.Contains(3) || !l.Contains(4) {
+			t.Errorf("Cache should have contained 2 elements")
+		}
+	})
+
+	t.Run("with aborted evictions", func(t *testing.T) {
+		t.Parallel()
+
+		onEvictCounter := 0
+		abortEviction := true
+		onEvicted := func(k interface{}, v interface{}) bool {
+			onEvictCounter++
+
+			// Abort the first eviction.
+			// The next entry should be evicted instead, then.
+			if abortEviction {
+				abortEviction = false
+				return false
+			}
+			return true
+		}
+		l, err := NewLRU(2, onEvicted)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		// Downsize
+		l.Add(1, 1)
+		l.Add(2, 2)
+		evicted := l.Resize(1)
+		if evicted != 1 {
+			t.Errorf("1 element should have been evicted: %v", evicted)
+		}
+		if onEvictCounter != 2 {
+			t.Errorf("onEvicted should have been called twice: %v", onEvictCounter)
+		}
+		if !l.Contains(1) {
+			t.Errorf("Element 1 should not have been evicted")
+		}
+		if l.Contains(2) {
+			t.Errorf("Element 2 should have been evicted")
+		}
+
+		l.Add(3, 3)
+		if l.Contains(1) {
+			t.Errorf("Element 1 should have been evicted")
+		}
+		if l.Contains(2) {
+			t.Errorf("Element 2 should have been evicted")
+		}
+		if !l.Contains(3) {
+			t.Errorf("Element 3 should not have been evicted")
+		}
+
+		// Upsize
+		evicted = l.Resize(2)
+		if evicted != 0 {
+			t.Errorf("0 elements should have been evicted: %v", evicted)
+		}
+
+		l.Add(4, 4)
+		if !l.Contains(3) || !l.Contains(4) {
+			t.Errorf("Cache should have contained 2 elements")
+		}
+	})
 }


### PR DESCRIPTION
## Goal of this PR

This PR redesigns the eviction system of the LRU cache so that:

* Instead of being a call back, the given function is an eviction handler which is called BEFORE an eviction happens
* If this handler returns `false`, the eviction is aborted, and the element that was supposed to get evicted gets pushed back to the front of the eviction list
* All tests were updated with cases where evictions are aborted, to verify that it works as expected

## Why do we need this?

In our new trie storage in Flow DPS, we need to be able to write entries in the database transaction before they get removed from the LRU cache. We might want to abort an eviction if the oldest value is not yet committed on disk (dirty) and instead evict one that is already on disk (clean).

When the cache is full of dirty transactions, insertions become blocking (because we can no longer evict anything) so we need to go through all of the cached entries and add them to a database transaction and then unlock the cache.

## Additional Notes

I realize that the tests could be a bit more exhaustive, but the original tests already were not great and I don't want to spend too much time on this since we would ideally like to release the trie improvements ASAP. We can always improve the tests later on.